### PR TITLE
Improves the Logger implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ analysis:
 	@scripts/analysis.sh
 
 test:
-	@shellcheck scripts/*.sh
 	@scripts/test.sh
 
 build:

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -20,8 +20,6 @@
 
 package logger
 
-import "io"
-
 // LogLevel describes the log level type a logger can write with
 type LogLevel byte
 
@@ -45,14 +43,14 @@ const (
 //
 // WriteString writes all bytes of the string to the logger
 //
-// ReportingTo creates a new writer that reports every written byte slice to the logger on the given log level
+// ReportingOn creates a new writer that reports every written byte slice to the logger on the given log level
 type Logger interface {
 	ChannelProvider() ChannelProvider
 	Name() string
 	ID() int
 	Write(p []byte, level LogLevel) (n int, err error)
 	WriteString(s string, level LogLevel) error
-	ReportingTo(level LogLevel) io.Writer
+	ReportingOn(level LogLevel) ReportingWriter
 }
 
 // SimpleChanneledLogger is an implementation of the Logger interface that the loggers will use in order to store their logged values
@@ -90,22 +88,7 @@ func (l *SimpleChanneledLogger) WriteString(s string, level LogLevel) error {
 	return err
 }
 
-// ReportingTo creates a new writer that reports every written byte slice to the logger on the given log level
-func (l *SimpleChanneledLogger) ReportingTo(level LogLevel) io.Writer {
-	return &loggerReporter{
-		level:  level,
-		logger: l,
-	}
-}
-
-// loggerReporter is a simple internal implementation of the writer interface.
-// it forwards every byte slice to its master logger
-type loggerReporter struct {
-	logger Logger
-	level  LogLevel
-}
-
-// Write simply forwards every call to the master
-func (l *loggerReporter) Write(p []byte) (n int, err error) {
-	return l.logger.Write(p, l.level)
+// ReportingOn creates a new writer that reports every written byte slice to the logger on the given log level
+func (l *SimpleChanneledLogger) ReportingOn(level LogLevel) ReportingWriter {
+	return NewSimpleLoggerReporter(l , level)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -25,10 +25,10 @@ type LogLevel byte
 
 const (
 	// Info represents the logging level info.
-	Info LogLevel = 0
+	Info LogLevel = iota
 
 	// Error represents the logging level info
-	Error LogLevel = 1
+	Error
 )
 
 // Logger defines an observable logger
@@ -49,7 +49,7 @@ type Logger interface {
 	Name() string
 	ID() int
 	Write(p []byte, level LogLevel) (n int, err error)
-	WriteString(s string, level LogLevel) error
+	WriteString(level LogLevel, s string) error
 	ReportingOn(level LogLevel) ReportingWriter
 }
 
@@ -83,7 +83,7 @@ func (l *SimpleChanneledLogger) Write(b []byte, level LogLevel) (int, error) {
 }
 
 // WriteString writes an entire string to the logger instance
-func (l *SimpleChanneledLogger) WriteString(s string, level LogLevel) error {
+func (l *SimpleChanneledLogger) WriteString(level LogLevel, s string) error {
 	_, err := l.Write([]byte(s), level)
 	return err
 }

--- a/pkg/logger/logger_message.go
+++ b/pkg/logger/logger_message.go
@@ -24,6 +24,7 @@ package logger
 type ChannelMessage struct {
 	Logger  Logger
 	Message []byte
+	Level   LogLevel
 }
 
 // MessageAsString Returns the message as string
@@ -32,9 +33,10 @@ func (c ChannelMessage) MessageAsString() string {
 }
 
 // NewChannelMessage is a simple constructor for the ChannelMessage struct
-func NewChannelMessage(logger Logger, message []byte) ChannelMessage {
+func NewChannelMessage(logger Logger, message []byte, level LogLevel) ChannelMessage {
 	return ChannelMessage{
 		Logger:  logger,
 		Message: message,
+		Level:   level,
 	}
 }

--- a/pkg/logger/logger_reporter.go
+++ b/pkg/logger/logger_reporter.go
@@ -1,0 +1,70 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package logger
+
+import "errors"
+
+// ReporterReviewer defines a method that reviews a byte slice and returns if it should be passed to the logger
+type ReporterReviewer func(p []byte) error
+
+// ReportingWriter is a writer that is able to review the written bytes
+//
+// Write writes the bytes to the writer
+//
+// ReviewWith sets the Reporters reviewer. A ReportingWriter can have only on reviewer
+type ReportingWriter interface {
+	Write(p []byte) (n int, err error)
+	ReviewWith(reviewer ReporterReviewer) ReportingWriter
+}
+
+// ReportingLoggerWriter is a simple internal implementation of the writer interface.
+// it forwards every byte slice to its master logger
+type ReportingLoggerWriter struct {
+	logger   Logger
+	level    LogLevel
+	reviewer ReporterReviewer
+}
+
+// NewSimpleLoggerReporter creates a new reporter that forwards every written byte to the logger
+func NewSimpleLoggerReporter(logger Logger, level LogLevel) *ReportingLoggerWriter {
+	return &ReportingLoggerWriter{logger: logger, level: level, reviewer: func(p []byte) error {
+		return nil
+	}}
+}
+
+// ReviewWith sets the Reporters reviewer. A ReportingWriter can have only on reviewer
+func (l *ReportingLoggerWriter) ReviewWith(reviewer ReporterReviewer) ReportingWriter {
+	l.reviewer = reviewer
+	return l
+}
+
+// Write simply forwards every call to the master
+func (l *ReportingLoggerWriter) Write(p []byte) (n int, err error) {
+	if l.reviewer == nil {
+		panic(errors.New("the logger reporter was initialized without a basic reviewer. Always use the constructor"))
+	}
+
+	if e := l.reviewer(p); e != nil {
+		return 0, e // Return the error here and don't write it
+	}
+
+	return l.logger.Write(p, l.level) // Forward it
+}

--- a/pkg/logger/logger_suite_test.go
+++ b/pkg/logger/logger_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestMerkhet(t *testing.T) {
+func TestLogger(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "disrupt-o-meter pkg logger suite")
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -53,8 +53,8 @@ var _ = Describe("Logger code test", func() {
 		})
 
 		It("should forward messages correctly", func() {
-			logger.WriteString("test")
-			logger.WriteString("more-tests")
+			logger.WriteString("test", Info)
+			logger.WriteString("more-tests", Info)
 			Expect(channelProvider.Read().MessageAsString()).To(BeEquivalentTo("test"))
 			Expect(channelProvider.Read().MessageAsString()).To(BeEquivalentTo("more-tests"))
 		})
@@ -72,8 +72,8 @@ var _ = Describe("Logger code test", func() {
 
 			go cluster.StartListening()
 
-			logger.WriteString("first")
-			logger.WriteString("second")
+			logger.WriteString("first", Info)
+			logger.WriteString("second", Info)
 			close(channelProvider.Channel()) // Ends all communication as we wanna unit test on main thread
 		})
 
@@ -87,8 +87,8 @@ var _ = Describe("Logger code test", func() {
 
 			go cluster.StartListening()
 
-			logger.WriteString("first")
-			loggerFactory.NewChanneledLogger("other-logger").WriteString("second")
+			logger.WriteString("first", Info)
+			loggerFactory.NewChanneledLogger("other-logger").WriteString("second", Info)
 			close(channelProvider.Channel()) // Ends all communication as we wanna unit test on main thread
 		})
 
@@ -107,9 +107,9 @@ var _ = Describe("Logger code test", func() {
 
 			go cluster.StartListening()
 			go func() {
-				logger.WriteString("first")
+				logger.WriteString("first", Info)
 				time.Sleep(time.Second)
-				loggerFactory.NewChanneledLogger("other-logger").WriteString("second")
+				loggerFactory.NewChanneledLogger("other-logger").WriteString("second", Info)
 
 				close(channelProvider.Channel()) // Ends all communication as we wanna unit test on main thread
 			}()
@@ -121,6 +121,19 @@ var _ = Describe("Logger code test", func() {
 			result := ChunkSlice(first+second+third+fourth, 4)
 
 			Expect(len(result)).To(BeEquivalentTo(5))
+		})
+
+		It("should log different levels", func() {
+			logger.ReportingTo(Info).Write([]byte("info"))
+			logger.ReportingTo(Error).Write([]byte("error"))
+
+			infoMessage := channelProvider.Read()
+			Expect(infoMessage.Level).To(BeEquivalentTo(Info))
+			Expect(infoMessage.Message).To(BeEquivalentTo("info"))
+
+			errorMessage := channelProvider.Read()
+			Expect(errorMessage.Level).To(BeEquivalentTo(Error))
+			Expect(errorMessage.Message).To(BeEquivalentTo("error"))
 		})
 
 		It("Should send messages to the terminal correctly", func(done Done) {
@@ -140,9 +153,9 @@ var _ = Describe("Logger code test", func() {
 			go c.StartListening()
 
 			go func() {
-				logger.WriteString("\033[31m1")
-				logger.WriteString("\033[31m2")
-				other.WriteString("\033[32mdone")
+				logger.WriteString("\033[31m1", Info)
+				logger.WriteString("\033[31m2", Info)
+				other.WriteString("\033[32mdone", Info)
 				close(channelProvider.Channel())
 			}()
 		}, 5*1000)

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -124,8 +124,8 @@ var _ = Describe("Logger code test", func() {
 		})
 
 		It("should log different levels", func() {
-			logger.ReportingTo(Info).Write([]byte("info"))
-			logger.ReportingTo(Error).Write([]byte("error"))
+			logger.ReportingOn(Info).Write([]byte("info"))
+			logger.ReportingOn(Error).Write([]byte("error"))
 
 			infoMessage := channelProvider.Read()
 			Expect(infoMessage.Level).To(BeEquivalentTo(Info))
@@ -134,6 +134,15 @@ var _ = Describe("Logger code test", func() {
 			errorMessage := channelProvider.Read()
 			Expect(errorMessage.Level).To(BeEquivalentTo(Error))
 			Expect(errorMessage.Message).To(BeEquivalentTo("error"))
+		})
+
+		It("should notify the reviewers", func() {
+			logger.ReportingOn(Info).
+				ReviewWith(func(p []byte) error {
+					Expect(string(p)).To(BeEquivalentTo("info"))
+					return nil
+				}).
+				Write([]byte("info"))
 		})
 
 		It("Should send messages to the terminal correctly", func(done Done) {

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -53,8 +53,8 @@ var _ = Describe("Logger code test", func() {
 		})
 
 		It("should forward messages correctly", func() {
-			logger.WriteString("test", Info)
-			logger.WriteString("more-tests", Info)
+			logger.WriteString(Info, "test")
+			logger.WriteString(Info, "more-tests")
 			Expect(channelProvider.Read().MessageAsString()).To(BeEquivalentTo("test"))
 			Expect(channelProvider.Read().MessageAsString()).To(BeEquivalentTo("more-tests"))
 		})
@@ -72,8 +72,8 @@ var _ = Describe("Logger code test", func() {
 
 			go cluster.StartListening()
 
-			logger.WriteString("first", Info)
-			logger.WriteString("second", Info)
+			logger.WriteString(Info, "first")
+			logger.WriteString(Info, "second")
 			close(channelProvider.Channel()) // Ends all communication as we wanna unit test on main thread
 		})
 
@@ -87,8 +87,8 @@ var _ = Describe("Logger code test", func() {
 
 			go cluster.StartListening()
 
-			logger.WriteString("first", Info)
-			loggerFactory.NewChanneledLogger("other-logger").WriteString("second", Info)
+			logger.WriteString(Info, "first")
+			loggerFactory.NewChanneledLogger("other-logger").WriteString(Info, "second")
 			close(channelProvider.Channel()) // Ends all communication as we wanna unit test on main thread
 		})
 
@@ -107,9 +107,9 @@ var _ = Describe("Logger code test", func() {
 
 			go cluster.StartListening()
 			go func() {
-				logger.WriteString("first", Info)
+				logger.WriteString(Info, "first")
 				time.Sleep(time.Second)
-				loggerFactory.NewChanneledLogger("other-logger").WriteString("second", Info)
+				loggerFactory.NewChanneledLogger("other-logger").WriteString(Info, "second")
 
 				close(channelProvider.Channel()) // Ends all communication as we wanna unit test on main thread
 			}()
@@ -162,9 +162,9 @@ var _ = Describe("Logger code test", func() {
 			go c.StartListening()
 
 			go func() {
-				logger.WriteString("\033[31m1", Info)
-				logger.WriteString("\033[31m2", Info)
-				other.WriteString("\033[32mdone", Info)
+				logger.WriteString(Info, "\033[31m1")
+				logger.WriteString(Info, "\033[31m2")
+				other.WriteString(Info, "\033[32mdone")
 				close(channelProvider.Channel())
 			}()
 		}, 5*1000)

--- a/pkg/merkhet/merkhet_suite_test.go
+++ b/pkg/merkhet/merkhet_suite_test.go
@@ -111,7 +111,7 @@ func (l *LoggerMock) Write(p []byte, level logger.LogLevel) (n int, err error) {
 	return l.Buffer.Write(p)
 }
 
-func (l *LoggerMock) WriteString(s string, level logger.LogLevel) error {
+func (l *LoggerMock) WriteString(level logger.LogLevel, s string) error {
 	_, err := l.Write([]byte(s), level)
 	return err
 }

--- a/pkg/merkhet/merkhet_suite_test.go
+++ b/pkg/merkhet/merkhet_suite_test.go
@@ -22,7 +22,6 @@ package merkhet_test
 
 import (
 	"bytes"
-	"io"
 	"testing"
 
 	"github.com/homeport/disrupt-o-meter/pkg/logger"
@@ -96,8 +95,8 @@ type LoggerMock struct {
 	Buffer *bytes.Buffer
 }
 
-func (l *LoggerMock) ReportingTo(level logger.LogLevel) io.Writer {
-	return nil
+func (l *LoggerMock) ReportingOn(level logger.LogLevel) logger.ReportingWriter {
+	return logger.NewSimpleLoggerReporter(l, level)
 }
 
 func (l *LoggerMock) Name() string {

--- a/pkg/merkhet/merkhet_suite_test.go
+++ b/pkg/merkhet/merkhet_suite_test.go
@@ -22,6 +22,7 @@ package merkhet_test
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	"github.com/homeport/disrupt-o-meter/pkg/logger"
@@ -95,6 +96,10 @@ type LoggerMock struct {
 	Buffer *bytes.Buffer
 }
 
+func (l *LoggerMock) ReportingTo(level logger.LogLevel) io.Writer {
+	return nil
+}
+
 func (l *LoggerMock) Name() string {
 	return "LoggerMock"
 }
@@ -103,12 +108,12 @@ func (l *LoggerMock) ID() int {
 	return 0
 }
 
-func (l *LoggerMock) Write(p []byte) (n int, err error) {
+func (l *LoggerMock) Write(p []byte, level logger.LogLevel) (n int, err error) {
 	return l.Buffer.Write(p)
 }
 
-func (l *LoggerMock) WriteString(s string) error {
-	_, err := l.Write([]byte(s))
+func (l *LoggerMock) WriteString(s string, level logger.LogLevel) error {
+	_, err := l.Write([]byte(s), level)
 	return err
 }
 


### PR DESCRIPTION
This commit splits the logger implementation into the logger itself
which now provides a writer instance rather than implementing it.

This change allows one logger instance to create multiple loggers
"child" writers that all report to the same logger instance.

A use case of this would be cmd.Stdout = logger.ReportingTo(Info)
This would redirect every output on the stdout channel to the master
logger with the log level info.

Note that this PR also changes the Makefile , as shell checks should have been moved out of the "test" target and are now in the "analysis" target

Fixes #33 