### PR TITLE
Improves the merket worker executions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ analysis:
 	@scripts/analysis.sh
 
 test:
-	@shellcheck scripts/*.sh
 	@scripts/test.sh
 
 build:

--- a/pkg/merkhet/merkhet.go
+++ b/pkg/merkhet/merkhet.go
@@ -24,13 +24,13 @@ import (
 	"github.com/homeport/disrupt-o-meter/pkg/logger"
 )
 
-// Merkhet deinfes a runnable mesaurement task that can be executed during the Cloud Foundery maintenance
+// Merkhet defines a runnable measurement task that can be executed during the Cloud Foundry maintenance
 //
 // Install installs the merkhet instance. This method call will be used to setup necessary dependencies of the merkhet
 //
-// PostConnect is called after DOM successfully authenticated against the cloud foundery instance
+// PostConnect is called after DOM successfully authenticated against the cloud foundry instance
 //
-// PostConnect is called after DOM successfully authenticated against the cloud foundery instance
+// PostConnect is called after DOM successfully authenticated against the cloud founery instance
 //
 // BuildResult creates a new Result instance containing the
 //
@@ -50,7 +50,7 @@ type Merkhet interface {
 //
 // Name returns the name provided in the configuration.
 //
-// ValidRun returns wether the provided total relative to the fails is still considered a viable run
+// ValidRun returns whether the provided total relative to the fails is still considered a viable run
 // The behaviour of this method is heavily reliant on the implementation
 type Configuration interface {
 	Name() string
@@ -78,13 +78,13 @@ func (p *PercentageConfiguration) Name() string {
 	return p.namedConfiguration.Name()
 }
 
-// ValidRun returns if the failed runs comapred to the total runs are below the provided percentage threshold
+// ValidRun returns if the failed runs compared to the total runs are below the provided percentage threshold
 func (p *PercentageConfiguration) ValidRun(totalRuns uint, failedRuns uint) bool {
 	return (float64(failedRuns) / float64(totalRuns)) <= p.percentageThreshold
 }
 
 // FlatConfiguration is an implementation of the Configuration interface that is based on a flat amount of failed runs
-// to calucalte viability
+// to calculate viability
 type FlatConfiguration struct {
 	namedConfiguration *namedConfiguration
 	flatThreshold      uint
@@ -95,22 +95,22 @@ func (f *FlatConfiguration) Name() string {
 	return f.namedConfiguration.Name()
 }
 
-// ValidRun returns if the failed runs comapred to the total runs are below the provided percentage threshold
+// ValidRun returns if the failed runs compared to the total runs are below the provided percentage threshold
 func (f *FlatConfiguration) ValidRun(totalRuns uint, failedRuns uint) bool {
 	return failedRuns <= f.flatThreshold
 }
 
-// NewPercentageConfiguration creates a new configuration intaces that uses a percentage threshold
-func NewPercentageConfiguration(name string, percentageTreshhold float64) *PercentageConfiguration {
+// NewPercentageConfiguration creates a new configuration instance that uses a percentage threshold
+func NewPercentageConfiguration(name string, percentageThreshold float64) *PercentageConfiguration {
 	return &PercentageConfiguration{
 		namedConfiguration: &namedConfiguration{
 			name: name,
 		},
-		percentageThreshold: percentageTreshhold,
+		percentageThreshold: percentageThreshold,
 	}
 }
 
-// NewFlatConfiguration creates a new configuration intaces that uses a flat threshold
+// NewFlatConfiguration creates a new configuration instance that uses a flat threshold
 func NewFlatConfiguration(name string, flatThreshold uint) *FlatConfiguration {
 	return &FlatConfiguration{
 		namedConfiguration: &namedConfiguration{

--- a/pkg/merkhet/merkhet.go
+++ b/pkg/merkhet/merkhet.go
@@ -37,13 +37,20 @@ import (
 // Configuration returns the configuration instances the Merkhet is depending on
 //
 // Configuration returns the configuration instances the Merkhet is depending on
+//
+// RecordSuccessfulRun records one successful run
+//
+// RecordFailedRun records one failed run
 type Merkhet interface {
-	Install()
-	PostConnect()
-	Execute()
+	Install() error
+	PostConnect() error
+	Execute() error
 	BuildResult() Result
 	Configuration() Configuration
 	Logger() logger.Logger
+
+	RecordSuccessfulRun()
+	RecordFailedRun()
 }
 
 // Configuration contains the passed configuration values for a Merkhet instance
@@ -54,7 +61,7 @@ type Merkhet interface {
 // The behaviour of this method is heavily reliant on the implementation
 type Configuration interface {
 	Name() string
-	ValidRun(totalRuns uint, failedRuns uint) bool
+	ValidRun(totalRuns int, failedRuns int) bool
 }
 
 // namedConfiguration is a simple structure containing the name of a MerhetConfiguration
@@ -79,7 +86,7 @@ func (p *PercentageConfiguration) Name() string {
 }
 
 // ValidRun returns if the failed runs compared to the total runs are below the provided percentage threshold
-func (p *PercentageConfiguration) ValidRun(totalRuns uint, failedRuns uint) bool {
+func (p *PercentageConfiguration) ValidRun(totalRuns int, failedRuns int) bool {
 	return (float64(failedRuns) / float64(totalRuns)) <= p.percentageThreshold
 }
 
@@ -87,7 +94,7 @@ func (p *PercentageConfiguration) ValidRun(totalRuns uint, failedRuns uint) bool
 // to calculate viability
 type FlatConfiguration struct {
 	namedConfiguration *namedConfiguration
-	flatThreshold      uint
+	flatThreshold      int
 }
 
 // Name returns the name stored in the configuration delegate
@@ -96,7 +103,7 @@ func (f *FlatConfiguration) Name() string {
 }
 
 // ValidRun returns if the failed runs compared to the total runs are below the provided percentage threshold
-func (f *FlatConfiguration) ValidRun(totalRuns uint, failedRuns uint) bool {
+func (f *FlatConfiguration) ValidRun(totalRuns int, failedRuns int) bool {
 	return failedRuns <= f.flatThreshold
 }
 
@@ -111,7 +118,7 @@ func NewPercentageConfiguration(name string, percentageThreshold float64) *Perce
 }
 
 // NewFlatConfiguration creates a new configuration instance that uses a flat threshold
-func NewFlatConfiguration(name string, flatThreshold uint) *FlatConfiguration {
+func NewFlatConfiguration(name string, flatThreshold int) *FlatConfiguration {
 	return &FlatConfiguration{
 		namedConfiguration: &namedConfiguration{
 			name: name,

--- a/pkg/merkhet/merkhet_consumer.go
+++ b/pkg/merkhet/merkhet_consumer.go
@@ -1,0 +1,56 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package merkhet
+
+// ConsumerMethod describes the type of the methods allowed to consumer a merkhet
+type ConsumerMethod func(merkhet Merkhet, relay ControllerChannel)
+
+// Consumer is a simple consumer method that can be called against a merkhet
+type Consumer struct {
+	consumerMethod ConsumerMethod
+	sync           bool
+}
+
+// Consume consumes the passed merkhet instance
+func (c Consumer) Consume(m Merkhet, relay ControllerChannel) {
+	c.consumerMethod(m, relay)
+}
+
+// Sync returns if the consumer can run synced with its worker
+func (c Consumer) Sync() bool {
+	return c.sync
+}
+
+// ConsumeSync creates a synced Consumer
+func ConsumeSync(m ConsumerMethod) Consumer {
+	return Consumer{
+		consumerMethod: m,
+		sync:           true,
+	}
+}
+
+// ConsumeAsync creates a synced Consumer
+func ConsumeAsync(m ConsumerMethod) Consumer {
+	return Consumer{
+		consumerMethod: m,
+		sync:           false,
+	}
+}

--- a/pkg/merkhet/merkhet_pool.go
+++ b/pkg/merkhet/merkhet_pool.go
@@ -33,7 +33,7 @@ package merkhet
 type Pool interface {
 	StartWorker(merkhet Merkhet)
 	Size() uint
-	ForEach(consumer func(m Merkhet))
+	ForEach(consumer Consumer)
 	Shutdown()
 }
 
@@ -45,7 +45,7 @@ type SimplePool struct {
 // StartWorker pushes a new merkhet instance into the Pool
 func (s *SimplePool) StartWorker(m Merkhet) {
 	worker := NewMerkhetWorker(m)
-	go worker.StartWorker() //Start the worker intance in a different go routine
+	go worker.StartWorker() //Start the worker instance in a different go routine
 
 	s.workers = append(s.workers, worker)
 }
@@ -56,7 +56,7 @@ func (s *SimplePool) Size() uint {
 }
 
 // ForEach executes the provided function for each Merkhet instance currently managed by the pool
-func (s *SimplePool) ForEach(consumer func(m Merkhet)) {
+func (s *SimplePool) ForEach(consumer Consumer) {
 	for _, worker := range s.workers {
 		worker.ControllerChannel() <- consumer
 	}

--- a/pkg/merkhet/merkhet_results.go
+++ b/pkg/merkhet/merkhet_results.go
@@ -22,7 +22,7 @@ package merkhet
 
 // Result defines a statistic object that contains the data of a merkhet run
 //
-// TotalRuns returns the total amount of runs the merkhet instance ran
+// SuccessfulRuns returns the total amount of runs the merkhet instance ran
 // at the time this result instance was created
 //
 // FailedRuns returns the total amount of faild runs the merkhet instance that build
@@ -30,27 +30,27 @@ package merkhet
 //
 // Valid returns if the result was marked valid by the Merkhet instance that build it
 type Result interface {
-	TotalRuns() uint
-	FailedRuns() uint
+	SuccessfulRuns() int
+	FailedRuns() int
 	Valid() bool
 }
 
 // SimpleResult is a small implementation of the Result interface
 type SimpleResult struct {
-	totalRuns  uint
-	totalFails uint
+	totalRuns  int
+	totalFails int
 	valid      bool
 }
 
-// TotalRuns returns the total amount of runs the merkhet instance ran
+// SuccessfulRuns returns the total amount of runs the merkhet instance ran
 // at the time this result instance was created
-func (s *SimpleResult) TotalRuns() uint {
+func (s *SimpleResult) SuccessfulRuns() int {
 	return s.totalRuns
 }
 
 // FailedRuns returns the total amount of faild runs the merkhet instance that build
 // this result produced
-func (s *SimpleResult) FailedRuns() uint {
+func (s *SimpleResult) FailedRuns() int {
 	return s.totalFails
 }
 
@@ -60,7 +60,7 @@ func (s *SimpleResult) Valid() bool {
 }
 
 // NewMerkhetResult creates a new instance of the MerkhetResult interface
-func NewMerkhetResult(totalRuns uint, failedRuns uint, valid bool) *SimpleResult {
+func NewMerkhetResult(totalRuns int, failedRuns int, valid bool) *SimpleResult {
 	return &SimpleResult{
 		totalRuns:  totalRuns,
 		totalFails: failedRuns,

--- a/pkg/merkhet/merkhet_suite_test.go
+++ b/pkg/merkhet/merkhet_suite_test.go
@@ -36,40 +36,51 @@ func TestMerkhet(t *testing.T) {
 }
 
 type MerketCallback struct {
-	onInstall     func()
-	onPostConnect func()
-	onExecute     func()
+	onInstall     func() error
+	onPostConnect func() error
+	onExecute     func() error
 }
 
 type MerkhetMock struct {
-	Config      Configuration
-	LokggerMock logger.Logger
-	FailedRuns  uint
-	TotalRuns   uint
-	WillExecute bool
-	Callback    *MerketCallback
+	Config         Configuration
+	LokggerMock    logger.Logger
+	FailedRuns     int
+	SuccessfulRuns int
+	WillExecute    bool
+	Callback       *MerketCallback
 }
 
-func (s *MerkhetMock) Install() {
+func (s *MerkhetMock) RecordSuccessfulRun() {
+	s.SuccessfulRuns = s.SuccessfulRuns + 1
+}
+
+func (s *MerkhetMock) RecordFailedRun() {
+	s.FailedRuns = s.FailedRuns + 1
+}
+
+func (s *MerkhetMock) Install() error {
 	if s.Callback.onInstall != nil {
-		s.Callback.onInstall()
+		return s.Callback.onInstall()
 	}
+	return nil
 }
 
-func (s *MerkhetMock) PostConnect() {
+func (s *MerkhetMock) PostConnect() error {
 	if s.Callback.onPostConnect != nil {
-		s.Callback.onPostConnect()
+		return s.Callback.onPostConnect()
 	}
+	return nil
 }
 
-func (s *MerkhetMock) Execute() {
+func (s *MerkhetMock) Execute() error {
 	if s.Callback.onExecute != nil {
-		s.Callback.onExecute()
+		return s.Callback.onExecute()
 	}
+	return nil
 }
 
 func (s *MerkhetMock) BuildResult() Result {
-	return NewMerkhetResult(s.TotalRuns, s.FailedRuns, s.Configuration().ValidRun(s.TotalRuns, s.FailedRuns))
+	return NewMerkhetResult(s.SuccessfulRuns, s.FailedRuns, s.Configuration().ValidRun(s.SuccessfulRuns, s.FailedRuns))
 }
 
 func (s *MerkhetMock) Configuration() Configuration {
@@ -80,9 +91,9 @@ func (s *MerkhetMock) Logger() logger.Logger {
 	return s.LokggerMock
 }
 
-func NewMerkhetMock(config Configuration, totalRuns uint, fails uint, canExecute bool, callback *MerketCallback) *MerkhetMock {
+func NewMerkhetMock(config Configuration, totalRuns int, fails int, canExecute bool, callback *MerketCallback) *MerkhetMock {
 	return &MerkhetMock{
-		TotalRuns:   totalRuns,
+		SuccessfulRuns:   totalRuns,
 		FailedRuns:  fails,
 		WillExecute: canExecute,
 		Config:      config,

--- a/pkg/merkhet/merkhet_worker.go
+++ b/pkg/merkhet/merkhet_worker.go
@@ -57,11 +57,7 @@ func (s *SimpleWorkerTask) Merkhet() Merkhet {
 // This has to be called in a different go routine, or it will block the calling routine
 func (s *SimpleWorkerTask) StartWorker() {
 	for request := range s.ControllerChannel() {
-		if request.Sync() {
-			request.Consume(s.Merkhet(), s.ControllerChannel())
-		} else {
-			go request.Consume(s.Merkhet(), s.ControllerChannel())
-		}
+		request.Consume(s.Merkhet(), s.ControllerChannel())
 	}
 }
 


### PR DESCRIPTION
Workers can now executed syned or asynced consumers that can themselves
queue more consumers. This way we can run Execute calls async but store
the results of that execute call synced to avoid data races.

This PR fixes a bunch of typos

Fixes #34 